### PR TITLE
Load rails_12factor gem only on production.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.1.3'
 
 gem 'rails', '4.1.4'
 gem 'arel'
@@ -50,7 +50,7 @@ gem 'activeadmin', github: 'gregbell/active_admin'
 gem 'carrierwave'
 
 # for logging to work in heroku
-gem 'rails_12factor'
+gem 'rails_12factor', group: [:production, :staging]
 
 # for email validation
 gem 'email_validator'


### PR DESCRIPTION
Load rails_12factor gem only on production to disable multiple logging by rails in other environments.
