### PR TITLE
Use Thin in development and Unicorn in staging and production.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,12 +15,6 @@ gem 'pg'
 # for building JSON
 gem 'jbuilder', '~> 1.2'
 
-# HTTP server for Rack applications
-gem 'unicorn'
-
-# without this in development webrick is used
-gem "unicorn-rails"
-
 # for authentication
 gem 'devise', '3.2.3'
 
@@ -64,6 +58,8 @@ gem 'browser'
 gem 'haml-rails'
 
 group :development do
+  # HTTP server for Rack applications
+  gem 'thin'
 
   # mutes assets pipeline log messages
   gem 'quiet_assets'
@@ -79,4 +75,12 @@ group :test do
 
   # for test coverage report
   gem 'simplecov', require: false
+end
+
+group :staging, :production do
+  # HTTP server for Rack applications
+  gem 'unicorn'
+
+  # without this in development default one is used
+  gem "unicorn-rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    daemons (1.1.9)
     delayed_job (4.0.2)
       activesupport (>= 3.0, < 4.2)
     delayed_job_active_record (4.0.1)
@@ -99,6 +100,7 @@ GEM
     email_validator (1.4.0)
       activemodel
     erubis (2.7.0)
+    eventmachine (1.0.3)
     execjs (2.2.1)
     formtastic (2.3.0.rc3)
       actionpack (>= 3.0)
@@ -210,6 +212,10 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -261,6 +267,7 @@ DEPENDENCIES
   simplecov
   spring
   sprockets-rails (~> 2.0)
+  thin
   twitter-bootstrap-rails
   uglifier (>= 1.0.3)
   unicorn


### PR DESCRIPTION
This PR is sent because, currently we use Unicorn server for development env as well. But settings for Unicorn is not good for development env.

https://github.com/swjg-ventures/myautobrain/blob/df2ba03f250c6c2a031b1b696255095a8eacc814/config/unicorn.rb
- We can't use debugger properly because timeout is set for 30 seconds.
- No need of worker_processes set to 2 for development.

Either we can modify these settings based on dev and staging/production or we can use Thin directly.
