### PR TITLE
Disable ParamsParser middleware in development mode

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,6 @@ module Wheel
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-    config.middleware.insert_before ActionDispatch::ParamsParser, "CatchJsonParseErrors"
+
   end
 end

--- a/config/initializers/catch_json_parser_errors.rb
+++ b/config/initializers/catch_json_parser_errors.rb
@@ -1,0 +1,3 @@
+unless Rails.env.development?
+  Rails.application.config.middleware.insert_before ActionDispatch::ParamsParser, "CatchJsonParseErrors"
+end


### PR DESCRIPTION
During development its better to fail fast and display complete dump of exception, which is default behaviour.
`ParamsParser` catches original exception sometimes causing issues in complete display of exceptions. Disabling it in development mode helps track exceptions better. This can be enabled/ disabled as needed for development.
- Moved adding of `ParamsParser` middleware from application.rb to an initializer
- Added check to disable `ParamsParser` for ease of development.
