### PR TITLE
Remove upgrade warning 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       activesupport (>= 3.2, < 5)
     hashr (0.0.22)
     hike (1.2.3)
-    honeybadger (2.0.6)
+    honeybadger (2.0.11)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
       haml (~> 4.0.0)

--- a/bin/honeybadger
+++ b/bin/honeybadger
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'honeybadger/cli'
+Honeybadger::CLI.start(ARGV)

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,0 +1,2 @@
+---
+api_key: <%= Settings.honeybadger_api_key %>

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,7 +1,3 @@
-Honeybadger.configure do |config|
-  config.api_key = Settings.honeybadger_api_key
-end
-
 # When a DelayedJob operation fails then honeybadger should collect
 # contextual information like job name and the host.
 class HoneybadgerDelayedJobPlugin < Delayed::Plugin


### PR DESCRIPTION

`rake setup` is showing following warning.

```
UPGRADE WARNING: Honeybadger.configure was removed in v2.0 and has no effect. Please upgrade: https://www.honeybadger.io/s/gem-upgrade
```