### PR TITLE
 Add daemons gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,9 @@ gem 'mail_interceptor'
 # not used in development.
 gem 'unicorn', group: [:staging, :production]
 
+# For starting Delayed job background process
+gem 'daemons'
+
 group :development do
 
   # application server for development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.3)
   browser
   carrierwave
+  daemons
   delayed_job_active_record
   delayed_job_web (>= 1.2.0)
   devise (= 3.4.1)


### PR DESCRIPTION
 - Delayed job requires daemon gem if we want to run it as background
   process.
 - Thin gem also depends on daemons gem so it was working for a long
   time without explicitly requiring it.
 - But we moved thin in development and now it doesn't work in
   non-development environemnts.
 - Reference: https://github.com/collectiveidea/delayed_job#running-jobs.