### PR TITLE
 Update mail_interceptor settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,10 @@ gem 'browser'
 gem 'haml-rails'
 
 # intercepts outgoing emails in non-production environment
-gem 'mail_interceptor'
+gem 'mail_interceptor', github: 'bigbinary/mail_interceptor', group: [:development, :staging]
+
+# Adds prefix to the subject in emails
+gem 'email_prefixer'
 
 # HTTP server for Rack applications for staginng and production
 # See https://github.com/bigbinary/wheel/issues/43 for why unicorn is

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,13 @@ GIT
       sass-rails
 
 GIT
+  remote: git://github.com/bigbinary/mail_interceptor.git
+  revision: 3c6e9689e78a8edbf589d284b03a0146af421847
+  specs:
+    mail_interceptor (0.0.5)
+      activesupport
+
+GIT
   remote: git://github.com/mhfs/devise-async.git
   revision: f8f61910e6ef54fdc91ebf5088c0594be9dca19c
   specs:
@@ -110,6 +117,8 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     docile (1.1.5)
+    email_prefixer (1.1.0)
+      rails (>= 4.0)
     email_validator (1.5.0)
       activemodel
     erubis (2.7.0)
@@ -167,8 +176,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mail_interceptor (0.0.3)
-      activesupport
     mime-types (2.4.3)
     mini_portile (0.6.2)
     minitest (5.5.1)
@@ -303,6 +310,7 @@ DEPENDENCIES
   delayed_job_web (>= 1.2.0)
   devise (= 3.4.1)
   devise-async!
+  email_prefixer
   email_validator
   font-awesome-sass (~> 4.3.0)
   haml-rails
@@ -310,7 +318,7 @@ DEPENDENCIES
   honeybadger
   jbuilder (~> 1.2)
   jquery-rails
-  mail_interceptor
+  mail_interceptor!
   minitest-reporters
   pg
   quiet_assets

--- a/config/initializers/email_interceptor.rb
+++ b/config/initializers/email_interceptor.rb
@@ -1,0 +1,7 @@
+if Settings.intercept_and_forward_emails_to.present?
+  options = { forward_emails_to: Settings.intercept_and_forward_emails_to,
+              deliver_emails_to: ['@example.com'] }
+
+  interceptor = MailInterceptor::Interceptor.new(options)
+  ActionMailer::Base.register_interceptor(interceptor)
+end

--- a/config/initializers/email_prefixer.rb
+++ b/config/initializers/email_prefixer.rb
@@ -1,0 +1,3 @@
+EmailPrefixer.configure do |config|
+  config.stage_name = 'WHEEL'
+end

--- a/config/initializers/setup_email.rb
+++ b/config/initializers/setup_email.rb
@@ -5,8 +5,3 @@ ActionMailer::Base.delivery_method = Settings.mailer.delivery_method
 if Settings.mailer.delivery_method == :smtp
   ActionMailer::Base.smtp_settings = Settings.mailer.smtp_settings
 end
-
-interceptor = MailInterceptor::Interceptor.new({ forward_emails_to: Settings.intercept_and_forward_emails_to,
-                                                 deliver_emails_to: ["@company.com"],
-                                                 subject_prefix: Settings.subject_prefix_for_outgoing_emails })
-ActionMailer::Base.register_interceptor(interceptor)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,9 +41,6 @@ development:
 test:
   mailer:
     delivery_method: :test
-  intercept_and_forward_emails_to:
-    - john@example.com
-    - adam@example.com
 
 staging:
   mailer:


### PR DESCRIPTION
 - Updated mail_interceptor gem, added email_prefixer for prefixing
   emails.
 - Added initializer for email_prefixer and updated interceptor settings to
   register interceptor conditionally so that it won't be registered in
   test and production environments.