### PR TITLE
Fix honeybadger key

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,2 +1,2 @@
 ---
-api_key: <%= ENV['HONEYBADGER_API_KEY'] %>
+api_key: <%= Rails.application.secrets.honeybadger_api_key %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,6 +14,7 @@ default: &default
   subject_prefix_for_outgoing_emails: WHEEL
   mailer_default_from_email: "'Wheel' <notifications@wheel.com>"
   mailer_delivery_method: :smtp
+  honeybadger_api_key: <%= ENV['HONEYBADGER_API_KEY'] %>
 
   twilio:
     from_number: <%= ENV['TWILIO_FROM_NUMBER'] %>


### PR DESCRIPTION
- Moved setting of honeybadger api key to Rails secrets
- Started using the same from honeybadger config