### PR TITLE
turn off warning if a variable is used before it is defined

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,7 @@
     "no-multi-spaces": [0],
     "no-shadow": [0],
     "no-unused-vars": [1],
-    "no-use-before-define": [2, "nofunc"],
+    "no-use-before-define": [0, "nofunc"],
     "comma-dangle": "never"
   }
 }


### PR DESCRIPTION
In ReactNavite code it is common to have styles.xxx at the top
while styles is defined later.