### PR TITLE
allow function names starting with underscore

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
     "no-multi-spaces": [0],
     "no-shadow": [0],
     "no-unused-vars": [1],
+    "no-underscore-dangle": [0],
     "no-use-before-define": [0, "nofunc"],
     "comma-dangle": "never"
   }


### PR DESCRIPTION
statements like this._executeQuery is being flagged. This
PR would make such warnings go away.