### PR TITLE
eslintrc should warn if "if statement" is not properly formatted

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,10 @@
     //In ReactNavite code it is common to have styles.xxx at the top while styles is defined later. PR #85
     "no-use-before-define": [0, "nofunc"],
 
-    "comma-dangle": "never"
+    "comma-dangle": "never",
+
+    // Force space after keywords like if, else and before code blocks. PR #91
+    "space-after-keywords": [2],
+    "space-before-blocks": [2]
   }
 }


### PR DESCRIPTION
```
var name = "John";

// good
if ( name === 'mary' ) {
 console.log("it is Mary");
} else if (name === 'Susan') {
 console.log('it is Susan');
} else {
 console.log("it must be John")
}


// bad
if( name === 'mary' ){
 console.log("it is Mary");
}else if(name === 'Susan'){
 console.log('it is Susan');
}else{
 console.log("it must be John")
}