### PR TITLE
 Specify jQuery in env section to remove annoying warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
   "env": {
     "browser": true,
     "es6": true,
-    "node": true
+    "node": true,
+    "jquery": true  // This will remove warnings related to $ being undefined. PR #97
   },
   "ecmaFeatures": {
     "arrowFunctions": true,


### PR DESCRIPTION
 - ESLint warns about $ being not defined whenever jQuery code is used.
 - This change will stop such warnings.