### PR TITLE
A file that directly uses React will be warned

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,9 @@
     "node": true,
     "jquery": true  // This will remove warnings related to $ being undefined. PR #97
   },
+  "plugins": [
+    "react"        // This will remove warnings related to React not being defined. PR #98
+  ]
   "ecmaFeatures": {
     "arrowFunctions": true,
     "blockBindings": true,


### PR DESCRIPTION
If a file has only following code then eslintrc warns as `React is not defined`.

```
var AuthError = React.createClass({
  render() {
    return <div>Hello</div>
  }
})
```