### PR TITLE
Do not show uuid value in log in development mode

### DIFF
--- a/config/initializers/tagged_logging.rb
+++ b/config/initializers/tagged_logging.rb
@@ -1,1 +1,3 @@
-Rails.application.config.log_tags = [ :subdomain, :uuid ]
+if Rails.env.production? || Rails.env.staging?
+  Rails.application.config.log_tags = [ :subdomain, :uuid ]
+end


### PR DESCRIPTION
It takes precious terminal space in development mode.