### PR TITLE
Enable logging from dj

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -10,6 +10,17 @@ Delayed::Worker.read_ahead          = 10
 
 Delayed::Worker.delay_jobs          = !Rails.env.test?
 
+if ENV['HEROKU'].present?
+  Delayed::Worker.logger = Logger.new(STDOUT)
+else
+  Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+end
+
+if Delayed::Worker.delay_jobs && ($PROGRAM_NAME =~ /delayed_job/)
+  ActiveRecord::Base.logger = Delayed::Worker.logger
+  Rails.logger = Delayed::Worker.logger
+end
+
 # In production have default number of attempts ( which I think is 30 )
 if !Rails.env.production?
   Delayed::Worker.max_attempts        = 3


### PR DESCRIPTION
Currently `Rails.logger` message disappear in thin area. This will help see those logs.

It has been tested in Digital Ocean as well as heroku.

/cc @rkr090 @ershad @vipulnsward 