### PR TITLE
We need to remove the pid file in entrypoint to restart the puma workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ RUN mkdir -p /wheel
 WORKDIR /wheel
 ADD . /wheel
 RUN bundle install
-RUN rm /wheel/tmp/pids/server.pid && true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,5 @@ cd /wheel
 bundle install
 cp config/database.yml.docker config/database.yml
 bundle exec rake setup
+rm tmp/pids/server.pid || true
 bundle exec rails server -p 9000 -b 0.0.0.0


### PR DESCRIPTION
- Currently docker-compose up says that puma server is already running.

   web_1  | sample data was added successfully
   web_1  | => Booting Puma
   web_1  | => Rails 5.0.0.1 application starting in development on http://0.0.0.0:9000
   web_1  | => Run `rails server -h` for more startup options
   web_1  | Exiting
   web_1  | A server is already running. Check /wheel/tmp/pids/server.pid

- This check was added in Dockerfile but is needed in entrypoint
  script which is used by docker-compose and not in Dockerfile.
- Also used `||` in the command as this command fails for the first run.

@vipulnsward _a