### PR TITLE
Disable rack timeout in development

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,2 @@
+Rack::Timeout::Logger.disable if Rails.env.development?
 Rack::Timeout.service_timeout = 30 # seconds


### PR DESCRIPTION
The output from rack-timeout is just too excessive and makes debugging hard.

### Before

![before](https://cloud.githubusercontent.com/assets/2760306/20347439/2e7e3706-ac27-11e6-8611-1b1852da63b4.png)


### After

![after](https://cloud.githubusercontent.com/assets/2760306/20347443/34f8bef8-ac27-11e6-91d1-022912556791.png)
