### PR TITLE
Use params[:email] instead of params[:id] for authentication

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
+    jquery-growl-rails (1.1.9)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -345,6 +346,7 @@ DEPENDENCIES
   haml-rails
   inherited_resources!
   jbuilder (>= 2.2.13)
+  jquery-growl-rails
   jquery-rails
   listen (~> 3.0.5)
   mail_interceptor
@@ -371,4 +373,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.1
+   1.14.3

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::BaseController < ApplicationController
   end
 
   def authenticate_user_using_x_auth_token
-    user_email = params[:id].presence
+    user_email = request.headers['X-Auth-Email']
     auth_token = request.headers['X-Auth-Token'].presence
 
     user = user_email && User.find_by_email(user_email)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,13 +3,13 @@ class Api::V1::UsersController < Api::V1::BaseController
   skip_before_action :authenticate_user!, only: [:create]
   skip_before_action :authenticate_user_using_x_auth_token, only: [:create]
 
-  def show
-    @user = User.find_by(email: params[:id])
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
 
+  def show
     if @user
       render json: @user
     else
-      respond_with_error "User with email #{params[:id]} not found.", :not_found
+      respond_with_error "User with id #{params[:id]} not found.", :not_found
     end
   end
 
@@ -24,10 +24,8 @@ class Api::V1::UsersController < Api::V1::BaseController
   end
 
   def update
-    @user = User.find_by(email: params[:id])
-
     if @user.blank?
-      respond_with_error "User with email #{params[:id]} not found.", :not_found
+      respond_with_error "User with id #{params[:id]} not found.", :not_found
 
     elsif @user.update_attributes(user_params)
       render json: @user
@@ -38,10 +36,8 @@ class Api::V1::UsersController < Api::V1::BaseController
   end
 
   def destroy
-    @user = User.find_by(email: params[:id])
-
     if @user.blank?
-      respond_with_error "User with email #{params[:id]} not found.", :not_found
+      respond_with_error "User with id #{params[:id]} not found.", :not_found
 
     elsif @user.destroy
       render json: @user
@@ -52,6 +48,10 @@ class Api::V1::UsersController < Api::V1::BaseController
   end
 
   private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
 
   def user_params
     params.require(:user).permit(:email, :first_name, :last_name, :password, :password_confirmation)

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -5,7 +5,7 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
   def test_show_for_a_valid_user
     admin = users(:admin)
 
-    get api_v1_user_url(admin.email), params: { id: admin.email, format: :json },
+    get api_v1_user_url(admin), params: { format: :json },
         headers: headers(admin)
 
     assert_response :success
@@ -15,10 +15,10 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_show_when_email_is_not_present
     admin = users :admin
-    an_invalid_email = "this_email_is_not_present_in_db@example.com"
+    an_invalid_email = { "X-Auth-Email" => "this_email_is_not_present_in_db@example.com" }
 
-    get api_v1_user_url(an_invalid_email), params: { id: an_invalid_email, format: :json },
-        headers: headers(admin)
+    get api_v1_user_url(admin), params: { format: :json },
+        headers: headers(admin, an_invalid_email)
 
     assert_response 401
     assert_equal "Could not authenticate with the provided credentials",
@@ -74,10 +74,10 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_update_should_return_error_when_email_is_not_present
     admin = users(:admin)
-    an_invalid_email = "this_email_is_not_present_in_db@example.com"
+    an_invalid_email = { "X-Auth-Email" => "this_email_is_not_present_in_db@example.com" }
 
-    put api_v1_user_url(an_invalid_email), params: { id: an_invalid_email, format: :json },
-        headers: headers(admin)
+    put api_v1_user_url(admin), params: { format: :json },
+        headers: headers(admin, an_invalid_email)
 
     assert_response 401
     assert_equal "Could not authenticate with the provided credentials",
@@ -88,8 +88,8 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     admin = users(:admin)
     new_first_name = "John2"
 
-    put api_v1_user_url(admin.email), params: { id: admin.email, format: :json,
-                                                user: { first_name: new_first_name } },
+    put api_v1_user_url(admin), params: { format: :json,
+                                          user: { first_name: new_first_name } },
         headers: headers(admin)
 
     assert_response :success
@@ -100,10 +100,10 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
   def test_update_user_should_return_error_for_invalid_data
     admin = users(:admin)
 
-    put api_v1_user_url(admin.email), params: { id: admin.email, format: :json,
-                                                user: { password: "new test password",
-                                                        password_confirmation:
-                                                          "not matching confirmation" } },
+    put api_v1_user_url(admin), params: { format: :json,
+                                          user: { password: "new test password",
+                                                  password_confirmation:
+                                                    "not matching confirmation" } },
         headers: headers(admin)
 
     assert_response 422
@@ -126,7 +126,7 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     admin = users :admin
 
     assert_difference "User.count", -1 do
-      delete api_v1_user_url(admin.email), params: { id: admin.email, format: :json },
+      delete api_v1_user_url(admin), params: { format: :json },
              headers: headers(admin)
 
       assert_response :success
@@ -135,9 +135,9 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_destroy_should_return_error_if_email_is_not_present_in_database
     admin = users :admin
-    email = "this_email_is_not_present_in_db@example.com"
+    email = { "X-Auth-Email" => "this_email_is_not_present_in_db@example.com" }
 
-    delete api_v1_user_url(email), params: { id: email, format: :json }, headers: headers(admin)
+    delete api_v1_user_url(admin), params: { format: :json }, headers: headers(admin, email)
 
     assert_response 401
     assert_equal "Could not authenticate with the provided credentials",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,8 +50,9 @@ class ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 end
 
-def headers(user)
+def headers(user, options = {})
   {
-    "X-Auth-Token" => user.authentication_token
-  }
+    "X-Auth-Token" => user.authentication_token,
+    "X-Auth-Email" => user.email
+  }.merge(options)
 end


### PR DESCRIPTION
In [authenticate_user_using_x_auth_token](https://github.com/bigbinary/wheel/blob/90832fe13be52a29fd121695396dc44c85cf4723/app/controllers/api/v1/base_controller.rb#L30) method, we are fetching the email using `params[:id]`. This could conflict with routes which have `id` param. Should we change it to `params[:email]`?