### PR TITLE
Change controller tests to be the new style Rails 5 integration tests

### DIFF
--- a/test/controllers/active_admin/dashboard_controller_test.rb
+++ b/test/controllers/active_admin/dashboard_controller_test.rb
@@ -1,6 +1,6 @@
-require 'test_helper'
+require "test_helper"
 
-class ActiveAdmin::DashboardControllerTest < ActionController::TestCase
+class ActiveAdmin::DashboardControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
@@ -8,14 +8,17 @@ class ActiveAdmin::DashboardControllerTest < ActionController::TestCase
   end
 
   def test_index_success_for_super_admin
-    get :index
+    get active_admin_root_url
+
     assert_response :success
   end
 
-  def test_index_redirects_for_non_super_admin
+  def test_index_for_non_super_admin
     sign_in users(:nancy)
-    get :index
-    assert_response :forbidden
+
+    assert_raises ActionController::RoutingError do
+      get active_admin_root_url
+    end
   end
 
 end

--- a/test/controllers/api/v1/sessions_controller_test.rb
+++ b/test/controllers/api/v1/sessions_controller_test.rb
@@ -1,27 +1,32 @@
-require 'test_helper'
+require "test_helper"
 
-class Api::V1::SessionsControllerTest < ActionController::TestCase
+class Api::V1::SessionsControllerTest < ActionDispatch::IntegrationTest
 
   def test_valid_email_and_password_should_be_able_to_log_in
     admin = users :admin
-    post :create, params: { user: { email: admin.email, password: 'welcome' } }
+
+    post api_v1_login_url, params: { user: { email: admin.email, password: "welcome" } }, as: :json
+
     assert_response :success
   end
 
   def test_wrong_combination_of_email_and_password_should_not_be_able_to_log_in
-    non_existent_email = 'this_email_does_not_exist_in_db@example.email'
-    post :create, params: { user: { email: non_existent_email, password: 'welcome' } }
+    non_existent_email = "this_email_does_not_exist_in_db@example.email"
+
+    post api_v1_login_url, params: { user: { email: non_existent_email, password: "welcome" } },
+                           as: :json
+
     assert_response 401
-    assert_equal 'Incorrect email or password', JSON.parse(response.body)['error']
+    assert_equal "Incorrect email or password", response.parsed_body["error"]
   end
 
   def test_should_return_auth_token
     admin = users :admin
 
-    post :create, params: { user: { email: admin.email, password: 'welcome' } }
+    post api_v1_login_url, params: { user: { email: admin.email, password: "welcome" } }, as: :json
 
     assert_response :success
-    assert JSON.parse(response.body)['auth_token']
+    assert response.parsed_body["auth_token"]
   end
 
 end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,89 +1,96 @@
-require 'test_helper'
+require "test_helper"
 
-class Api::V1::UsersControllerTest < ActionController::TestCase
+class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_show_for_a_valid_user
     admin = users(:admin)
-    set_auth_headers!(admin)
 
-    get :show, params: { id: admin.email, format: :json }
+    get api_v1_user_url(admin.email), params: { id: admin.email, format: :json },
+        headers: headers(admin)
 
     assert_response :success
-    json = JSON.parse(response.body)
+    json = response.parsed_body
     assert_equal %w{ email first_name last_name current_sign_in_at }.sort, json.keys.sort
   end
 
   def test_show_when_email_is_not_present
     admin = users :admin
-    an_invalid_email = 'this_email_is_not_present_in_db@example.com'
-    set_auth_headers!(admin)
+    an_invalid_email = "this_email_is_not_present_in_db@example.com"
 
-    get :show, params: { id: an_invalid_email, format: :json }
+    get api_v1_user_url(an_invalid_email), params: { id: an_invalid_email, format: :json },
+        headers: headers(admin)
 
     assert_response 401
-    assert_equal "Could not authenticate with the provided credentials", JSON.parse(response.body)['error']
+    assert_equal "Could not authenticate with the provided credentials",
+                 response.parsed_body["error"]
   end
 
   def test_create_user_with_valid_info
-    valid_email = 'john@example.com'
+    valid_email = "john@example.com"
 
     valid_user_json = { email: valid_email,
-                        first_name: 'John',
-                        last_name: 'Smith',
-                        password: 'welcome',
-                        password_confirmation: 'welcome',
-                        phone_number: '1(555)555-5555' }
+                        first_name: "John",
+                        last_name: "Smith",
+                        password: "welcome",
+                        password_confirmation: "welcome",
+                        phone_number: "1(555)555-5555" }
 
     # Ensure that there are no users with this email in db
     User.where(email: valid_email).delete_all
 
-    assert_difference 'User.count', 1 do
-      post :create, params: { user: valid_user_json }
+    assert_difference "User.count", 1 do
+      post api_v1_users_url, params: { user: valid_user_json, format: :json }
+
       assert_response :success
     end
   end
 
   def test_create_user_should_return_error_for_invalid_data
-    valid_email = 'john@example.com'
+    valid_email = "john@example.com"
 
     invalid_user_json = { email: valid_email,
-                          first_name: 'John',
-                          last_name: 'Smith',
+                          first_name: "John",
+                          last_name: "Smith",
                           password: nil # Invalid password
                         }
 
     # Ensure that there are no users with this email in db
     User.where( email: valid_email ).delete_all
 
-    post :create, params: { user: invalid_user_json }
+    post api_v1_users_url, params: { user: invalid_user_json, format: :json }
+
     assert_response 422
-    assert_equal "Password can't be blank", JSON.parse(response.body)['error']
+    assert_equal "Password can't be blank", response.parsed_body["error"]
   end
 
   def test_update_should_not_succeed_without_authentication
     admin = users :admin
     json_data = admin.as_json
-    put :update, params: { id: admin.email, user: json_data }
+
+    put api_v1_user_url(admin.email), params: { id: admin.email, user: json_data, format: :json }
+
     assert_response 401
   end
 
   def test_update_should_return_error_when_email_is_not_present
     admin = users(:admin)
-    an_invalid_email = 'this_email_is_not_present_in_db@example.com'
-    set_auth_headers!(admin)
+    an_invalid_email = "this_email_is_not_present_in_db@example.com"
 
-    put :update, params: { id: an_invalid_email, format: :json }
+    put api_v1_user_url(an_invalid_email), params: { id: an_invalid_email, format: :json },
+        headers: headers(admin)
 
     assert_response 401
-    assert_equal "Could not authenticate with the provided credentials", JSON.parse(response.body)['error']
+    assert_equal "Could not authenticate with the provided credentials",
+                 response.parsed_body["error"]
   end
 
   def test_update_user_should_succeed_for_valid_data
     admin = users(:admin)
-    new_first_name = 'John2'
-    set_auth_headers!(admin)
+    new_first_name = "John2"
 
-    put :update, params: { id: admin.email, user: { first_name: new_first_name }, format: :json }
+    put api_v1_user_url(admin.email), params: { id: admin.email, format: :json,
+                                                user: { first_name: new_first_name } },
+        headers: headers(admin)
 
     assert_response :success
     admin.reload
@@ -93,46 +100,48 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
   def test_update_user_should_return_error_for_invalid_data
     admin = users(:admin)
 
-    set_auth_headers!(admin)
+    put api_v1_user_url(admin.email), params: { id: admin.email, format: :json,
+                                                user: { password: "new test password",
+                                                        password_confirmation:
+                                                          "not matching confirmation" } },
+        headers: headers(admin)
 
-    put :update, params: { id: admin.email, format: :json, user: { password: 'new test password', password_confirmation: 'not matching confirmation' } }
     assert_response 422
-
-    assert_equal "Password confirmation doesn't match Password", JSON.parse(response.body)['error'], response.body
+    assert_equal "Password confirmation doesn't match Password",
+                 response.parsed_body["error"],
+                 response.parsed_body
   end
 
   def test_destroy_should_not_be_invokable_without_authentication
     admin = users :admin
-    delete :destroy, params: { id: admin.email }
-    assert_response 401
 
-    assert_equal 'Could not authenticate with the provided credentials', JSON.parse(response.body)['error']
+    delete api_v1_user_url(admin.email), params: { id: admin.email, format: :json }
+
+    assert_response 401
+    assert_equal "Could not authenticate with the provided credentials",
+                 response.parsed_body["error"]
   end
 
   def test_destroy_should_destroy_user
     admin = users :admin
-    set_auth_headers!(admin)
 
-    assert_difference 'User.count', -1 do
-      delete :destroy, params: { id: admin.email, format: :json }
+    assert_difference "User.count", -1 do
+      delete api_v1_user_url(admin.email), params: { id: admin.email, format: :json },
+             headers: headers(admin)
+
       assert_response :success
     end
   end
 
   def test_destroy_should_return_error_if_email_is_not_present_in_database
     admin = users :admin
-    email = 'this_email_is_not_present_in_db@example.com'
+    email = "this_email_is_not_present_in_db@example.com"
 
-    set_auth_headers!(admin)
-
-    delete :destroy, params: { id: email, format: :json }
+    delete api_v1_user_url(email), params: { id: email, format: :json }, headers: headers(admin)
 
     assert_response 401
-    assert_equal "Could not authenticate with the provided credentials", JSON.parse(response.body)['error']
-  end
-
-  def set_auth_headers!(user)
-    request.headers['X-Auth-Token'] = user.authentication_token
+    assert_equal "Could not authenticate with the provided credentials",
+                 response.parsed_body["error"]
   end
 
 end

--- a/test/controllers/contacts_controller_test.rb
+++ b/test/controllers/contacts_controller_test.rb
@@ -1,34 +1,30 @@
-require 'test_helper'
+require "test_helper"
 
-class ContactsControllerTest < ActionController::TestCase
+class ContactsControllerTest < ActionDispatch::IntegrationTest
 
   def before_setup
     super
     ActionMailer::Base.deliveries.clear
   end
 
-  def setup
-    request.env["HTTP_REFERER"] = "http://test.com"
-  end
-
   def test_create_success
-    contact_param = { contact: { title: 'contact title',
-                                 body: 'some message',
-                                 email: 'bob@example.com' } }
-    post :create, params: contact_param
+    contact_param = { contact: { title: "contact title",
+                                 body: "some message",
+                                 email: "bob@example.com" } }
+    post contacts_url, params: contact_param
 
     assert_includes ActionMailer::Base.deliveries.last.from, contact_param[:contact][:email]
     assert_redirected_to pages_contact_us_path
-    assert_equal 'Thank you for your message. We will contact you soon!', flash[:notice]
+    assert_equal "Thank you for your message. We will contact you soon!", flash[:notice]
   end
 
   def test_create_failure
-    invalid_contact_param = { contact: { title: 'contact title',
-                                         body: 'some message',
-                                         email: 'bob' }}
-    post :create, params: invalid_contact_param
+    invalid_contact_param = { contact: { title: "contact title",
+                                         body: "some message",
+                                         email: "bob" }}
+    post contacts_url, params: invalid_contact_param
 
-    assert_select 'form#new_contact'
+    assert_select "form#new_contact"
     assert_nil ActionMailer::Base.deliveries.last
     assert_nil flash[:notice]
   end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,12 +1,12 @@
-require 'test_helper'
+require "test_helper"
 
-class HomeControllerTest < ActionController::TestCase
+class HomeControllerTest < ActionDispatch::IntegrationTest
 
   def test_index_renders_message
     admin = users :admin
     sign_in admin
 
-    get :index
+    get "/"
 
     assert_response :success
   end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,21 +1,24 @@
-require 'test_helper'
+require "test_helper"
 
-class PagesControllerTest < ActionController::TestCase
+class PagesControllerTest < ActionDispatch::IntegrationTest
 
   def test_index_success
-    get :index
+    admin = users(:admin)
+    sign_in(admin)
+
+    get pages_url
 
     assert_response :success
   end
 
   def test_contact_us_success
-    get :contact_us
+    get pages_contact_us_url
 
     assert_response :success
   end
 
   def test_about_success
-    get :about
+    get pages_about_url
 
     assert_response :success
   end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,26 +1,25 @@
-require 'test_helper'
+require "test_helper"
 
-class RegistrationsControllerTest < ActionController::TestCase
-
-  setup do
-    request.env['devise.mapping'] = Devise.mappings[:user]
-  end
+class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
   def test_successfull_user_registration
-    assert_difference('User.count') do
-      post :create, params: { user: { email: "nancy@test.example.com",
-                              first_name: "Nancy",
-                              last_name: "Smith",
-                              password: "welcome",
-                              phone_number: '1(555)555-5555',
-                              password_confirmation: "welcome" } }
+    assert_difference("User.count") do
+      post user_registration_url, params: { user: { email: "nancy@test.example.com",
+                                                    first_name: "Nancy",
+                                                    last_name: "Smith",
+                                                    password: "welcome",
+                                                    phone_number: "1(555)555-5555",
+                                                    password_confirmation: "welcome" } }
     end
+
     assert_redirected_to root_path
   end
 
   def test_required_parameters
-    assert_no_difference('User.count') do
-      post :create, params: {user: {email: "steve@example.com", password: "welcome", password_confirmation: "welcome"}}
+    assert_no_difference("User.count") do
+      post user_registration_url, params: { user: { email: "steve@example.com",
+                                                    password: "welcome",
+                                                    password_confirmation: "welcome" } }
     end
 
     assert_response :success
@@ -30,11 +29,11 @@ class RegistrationsControllerTest < ActionController::TestCase
     nancy = users :nancy
     sign_in nancy
 
-    get :edit_password
+    get password_edit_url
     assert_response :success
 
-    valid_user_data = { password: 'new password', password_confirmation: 'new password', current_password: 'welcome' }
-    put :update_password, params: { user: valid_user_data }
+    valid_user_data = { password: "new password", password_confirmation: "new password", current_password: "welcome" }
+    put password_update_url, params: { user: valid_user_data }
     assert_redirected_to root_path
   end
 
@@ -43,12 +42,12 @@ class RegistrationsControllerTest < ActionController::TestCase
     old_password = nancy.encrypted_password
     sign_in nancy
 
-    get :edit_password
+    get password_edit_url
     assert_response :success
 
-    invalid_user_data = { password: 'new password', password_confirmation: 'new not matching password', current_password: 'welcome' }
+    invalid_user_data = { password: "new password", password_confirmation: "new not matching password", current_password: "welcome" }
 
-    put :update_password, params: { user: invalid_user_data }
+    put password_update_url, params: { user: invalid_user_data }
 
     nancy.reload
     assert_match "error", response.body
@@ -59,11 +58,11 @@ class RegistrationsControllerTest < ActionController::TestCase
     nancy = users :nancy
     sign_in nancy
 
-    get :edit
+    get edit_user_registration_url
     assert_response :success
 
-    valid_user_data = { first_name: 'John2', current_password: 'welcome' }
-    put :update, params: { user: valid_user_data }
+    valid_user_data = { first_name: "John2", current_password: "welcome" }
+    put "/users", params: { user: valid_user_data }
     assert_redirected_to root_path
     nancy.reload
     assert_equal nancy.first_name, valid_user_data[:first_name]

--- a/test/controllers/superadmin/users_controller_test.rb
+++ b/test/controllers/superadmin/users_controller_test.rb
@@ -1,25 +1,29 @@
-require 'test_helper'
+require "test_helper"
 
-class Superadmin::UsersControllerTest < ActionController::TestCase
+class Superadmin::UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_index_when_user_is_superadmin
     user = users :admin
     sign_in user
-    get :index
+
+    get superadmin_users_url
     assert_response :success
   end
 
   def test_index_when_user_is_not_superadmin
     user = users :nancy
     sign_in user
-    get :index
-    assert_response :forbidden
+
+    assert_raises ActionController::RoutingError do
+      get superadmin_users_url
+    end
   end
 
   def test_edit_user_modal_success_response
     user = users :admin
     sign_in user
-    get :edit, params: { id: users(:nancy) }
+
+    get edit_superadmin_user_url(users(:nancy))
     assert_response :success
   end
 
@@ -28,9 +32,9 @@ class Superadmin::UsersControllerTest < ActionController::TestCase
     sign_in admin
     nancy = users :nancy
 
-    post :update, params: { id: nancy, user: {first_name: 'Jane'} }
+    put superadmin_user_url(nancy), params: { user: { first_name: "Jane" } }
     nancy.reload
 
-    assert 'Jane', nancy.first_name
+    assert "Jane", nancy.first_name
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,12 @@ class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
 end
 
-class ActionController::TestCase
-  include Devise::Test::ControllerHelpers
+class ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+end
+
+def headers(user)
+  {
+    "X-Auth-Token" => user.authentication_token
+  }
 end


### PR DESCRIPTION
Change all test classes inheriting from `ActionController::TestCase` to inherit from `ActionDispatch::IntegrationTest` instead and make other changes as required.

Ref: https://youtu.be/_qG7A9LxBPw?t=738

