### PR TITLE
Use entire heroku url from env variables

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,7 +23,7 @@ default: &default
     bucket_name: <%= ENV['AWS_S3_BUCKET_NAME'] %>
 
   support_email: support@wheel.com
-  host: <%= ENV['APP_URL'] || "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com" || 'http://localhost:3000' %>
+  host: <%= ENV['APP_URL'] || ENV['HEROKU_APP_URL'] || 'http://localhost:3000' %>
 
 development:
   <<: *default

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -62,7 +62,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     valid_user_data = { first_name: "John2", current_password: "welcome" }
-    put "/users", params: { user: valid_user_data }
+    patch user_registration_url(nancy, format: :html), params: { user: valid_user_data }
     assert_redirected_to root_path
     nancy.reload
     assert_equal nancy.first_name, valid_user_data[:first_name]


### PR DESCRIPTION
@neerajdotname _a in Timely Radar I found that because of the existing code in the secrets.yml, the host in dev environment is taken by default as `https://.herokuapp.com`