### PR TITLE
Disable listen gem in development because of process leak issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,9 @@ group :development do
 
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console', '~> 3.0'
-  gem 'listen', '~> 3.0.5'
+
+  # Reenable after https://github.com/rails/rails/issues/26158 is fixed
+  # gem 'listen', '~> 3.0.5'
 
   # reports N+1 queries
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ GEM
     erubis (2.7.0)
     excon (0.51.0)
     execjs (2.7.0)
-    ffi (1.9.14)
     fog-aws (0.11.0)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
@@ -199,9 +198,6 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    listen (3.0.8)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -271,9 +267,6 @@ GEM
       activesupport (>= 3.0)
       i18n
       polyamorous (~> 1.3)
-    rb-fsevent (0.9.7)
-    rb-inotify (0.9.7)
-      ffi (>= 0.5.0)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rollbar (2.13.0)
@@ -348,7 +341,6 @@ DEPENDENCIES
   jbuilder (>= 2.2.13)
   jquery-growl-rails
   jquery-rails
-  listen (~> 3.0.5)
   mail_interceptor
   marginalia!
   minitest-reporters

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,5 +50,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end


### PR DESCRIPTION
I have been facing a lot of issues for past few weeks which are exactly as per the description of # https://github.com/rails/rails/issues/26158 . We can re enable this gem once we know the appropriate changes are made in rails.

@neerajdotname _a
