### PR TITLE
Add `prepend_before_action :authenticate_scope!` to resource based actions in `RegistrationController`

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,5 @@
 class RegistrationsController < Devise::RegistrationsController
-
+  prepend_before_action :authenticate_scope!, only: [:edit, :update, :edit_password, :update_password, :destroy]
   before_action :load_resource, only: [:edit_password, :update_password]
 
   def edit_password


### PR DESCRIPTION
We missed adding `prepend_before_action :authenticate_scope!` while adding `RegistrationsController` from https://github.com/plataformatec/devise/blob/v4.3.0/app/controllers/devise/registrations_controller.rb. Due to this while writing tests exception was raised. Explanation is below:
<img width="662" alt="screen shot 2017-07-27 at 1 45 32 pm" src="https://user-images.githubusercontent.com/7930484/28660760-eef35bee-72d1-11e7-8942-a6cc853affe5.png">
