### PR TITLE
Add daily cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,3 +91,20 @@ jobs:
       - store_artifacts:
           path: knapsack_minitest_report.json
           destination: knapsack_minitest_report.json
+
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - test
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - test
+      - build
   nightly:
     triggers:
       - schedule:
@@ -107,4 +107,4 @@ workflows:
               only:
                 - master
     jobs:
-      - test
+      - build


### PR DESCRIPTION
Since we don't do many changes on Wheel, added a cron to run everyday and verify things are ok.

This will report us issues like CVE, gem breakage, test failure, etc