### PR TITLE
[WIP] Fix Deprecation Warnings circle ci

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::UsersController < Api::V1::BaseController
     if @user.blank?
       respond_with_error "User with id #{params[:id]} not found.", :not_found
 
-    elsif @user.update_attributes(user_params)
+    elsif @user.update(user_params)
       render json: @user
 
     else

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Wheel
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.active_job.queue_adapter = :sidekiq
+    config.action_dispatch.return_only_media_type_on_content_type = false
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,4 +2,4 @@
 require_relative 'application'
 
 # Initialize the Rails application.
- Rails.application.class.module_parent_name
+ Rails.application.initialize!

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,4 +2,4 @@
 require_relative 'application'
 
 # Initialize the Rails application.
-Rails.application.initialize!
+ Rails.application.class.module_parent_name


### PR DESCRIPTION
I was able to remove all the Deprecated Warning except 
DEPRECATION WARNING: `Module#parent_name` has been renamed to `module_parent_name`. `parent_name` is deprecated and will be removed in Rails 6.1. 
I am currently looking into it