### PR TITLE
CircleCI builds fail fast for audit checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,12 @@ jobs:
           - wheel-yarn-deps
 
       - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+
+      # Bundler audit
+      - run:
+          shell: /bin/bash
+          command: bundle exec bundle-audit check --update
+
       - run: bin/yarn install --cache-folder vendor/node_modules
 
       # Store bundle cache
@@ -70,11 +76,6 @@ jobs:
       - run:
           shell: /bin/bash
           command: bundle exec rake test --trace
-
-      # Bundler audit
-      - run:
-          shell: /bin/bash
-          command: bundle exec bundle-audit check --update
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,6 @@ jobs:
 
       - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
 
-      # Bundler audit
-      - run:
-          shell: /bin/bash
-          command: bundle exec bundle-audit check --update
-
-      - run: bin/yarn install --cache-folder vendor/node_modules
-
       # Store bundle cache
       - save_cache:
           key: gem-cache-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
@@ -50,6 +43,13 @@ jobs:
           key: gem-cache
           paths:
             - vendor/bundle
+
+      # Bundler audit
+      - run:
+          shell: /bin/bash
+          command: bundle exec bundle-audit check --update
+
+      - run: bin/yarn install --cache-folder vendor/node_modules
 
       # Store yarn cache
       - save_cache:
@@ -70,7 +70,6 @@ jobs:
       - run: bin/yarn install --cache-folder vendor/node_modules
       - run: bin/webpack
       - run: bundle exec rails webpacker:compile
-
 
       # Unit tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 
       - checkout
 
-      # Download and cache dependencies
+      # Download cache dependencies
       - restore_cache:
           keys:
           - gem-cache-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
@@ -28,6 +28,7 @@ jobs:
           - wheel-yarn-deps-{{ .Branch }}
           - wheel-yarn-deps
 
+      # Bundle install
       - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
 
       # Store bundle cache
@@ -49,6 +50,11 @@ jobs:
           shell: /bin/bash
           command: bundle exec bundle-audit check --update
 
+      # Setup database
+      - run: cp config/database.yml.ci config/database.yml
+      - run: bundle exec rake db:create db:schema:load --trace
+
+      # Yarn install
       - run: bin/yarn install --cache-folder vendor/node_modules
 
       # Store yarn cache
@@ -65,9 +71,7 @@ jobs:
           paths:
             - vendor/node_modules
 
-      - run: cp config/database.yml.ci config/database.yml
-      - run: bundle exec rake db:create db:schema:load --trace
-      - run: bin/yarn install --cache-folder vendor/node_modules
+      # Generate assets
       - run: bin/webpack
       - run: bundle exec rails webpacker:compile
 


### PR DESCRIPTION
I have moved bundle tasks before moving to any Node tasks. This allows a build to fail fast without downloading any node modules in case of bundle audit errors.

Please read https://github.com/bigbinary/nitrohelp-web/issues/3083 for more information.