### PR TITLE
Enable zeitwerk mode for autoloading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Wheel
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults "6.0" # Enable zeitwerk mode in CRuby
     config.active_job.queue_adapter = :sidekiq
     config.action_dispatch.return_only_media_type_on_content_type = false
 


### PR DESCRIPTION
@neerajdotname _a Rails 6 should be using `zeitwerk` mode for autoloading instead of `classic` autoloader. 

Without this change, Sidekiq jobs get stuck in `development` when they are started after a worker reboot (if the concurrency is set to > 1).

Reference:

1. https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#enabling-zeitwerk-mode
2. https://github.com/rails/rails/issues/36810#issuecomment-527544119