### PR TITLE
Changes in latest rubocop version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-rails
+
 AllCops:
   TargetRubyVersion: 2.6
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,12 +21,6 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
@@ -50,7 +44,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -131,12 +125,12 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 # Detect hard tabs, no hard tabs.
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
 
 # This cop looks for trailing blank lines and a final newline in the source code.
 # This is being disabled because the requirement to have a final newline is illogical.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: false
 
 # No trailing whitespace.
@@ -144,7 +138,7 @@ Layout/TrailingWhitespace:
   Enabled: true
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 # Align `end` with the matching keyword or starting expression except for

--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,8 @@ group :development do
   gem "bullet"
 
   # A Ruby static code analyzer, based on the community Ruby style guide
-  gem 'rubocop', '~> 0.82.0', require: false
+  gem "rubocop", "~> 0.82.0", require: false
+  gem "rubocop-rails"
 
   # Patch-level verification for Bundler.
   gem "bundler-audit", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :development do
   gem "bullet"
 
   # A Ruby static code analyzer, based on the community Ruby style guide
-  gem "rubocop", require: false
+  gem 'rubocop', '~> 0.82.0', require: false
 
   # Patch-level verification for Bundler.
   gem "bundler-audit", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,13 +87,13 @@ GEM
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
-    coderay (1.1.2)
+    coderay (1.1.3)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     crass (1.0.6)
     devise (4.7.1)
       bcrypt (~> 3.0)
@@ -108,7 +108,7 @@ GEM
       activemodel
     erubi (1.9.0)
     execjs (2.7.0)
-    ffi (1.12.2)
+    ffi (1.13.0)
     font-awesome-sass (4.3.2.1)
       sass (~> 3.2)
     formtastic (3.1.5)
@@ -119,7 +119,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
-    honeybadger (4.6.0)
+    honeybadger (4.7.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.11.0)
@@ -131,7 +131,7 @@ GEM
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jquery-growl-rails (1.1.9)
-    jquery-rails (4.3.5)
+    jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -173,7 +173,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     parallel (1.19.1)
-    parser (2.7.1.2)
+    parser (2.7.1.3)
       ast (~> 2.4.0)
     pg (1.2.3)
     polyamorous (2.3.2)
@@ -228,7 +228,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.4)
-    responders (3.0.0)
+    responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
@@ -251,7 +251,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.3.0)
+    sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -307,9 +307,9 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
-    websocket-driver (0.7.1)
+    websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     zeitwerk (2.3.0)
 
 PLATFORMS
@@ -340,7 +340,7 @@ DEPENDENCIES
   puma (~> 3.12)
   rack-timeout
   rails (~> 6.0.3)
-  rubocop
+  rubocop (~> 0.82.0)
   ruby_audit
   sass-rails (>= 5.0.3)
   sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,10 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-rails (2.5.2)
+      activesupport
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     ruby_audit (1.2.0)
       bundler-audit (~> 0.6.0)
@@ -341,6 +345,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 6.0.3)
   rubocop (~> 0.82.0)
+  rubocop-rails
   ruby_audit
   sass-rails (>= 5.0.3)
   sidekiq


### PR DESCRIPTION
#### The name of few cops in rubocop.yml file has been changed in the latest rubocop version.

- Freezed rubocop version to 0.82.0 in gemfile.
- Changed the name of cops in the rubocop.yml file.
- Removed the cop - BracesAroundHashParameters. As it has been removed from the rubocop latest version itself.
- Added rubocop-rails gem and required it in the rubocop.yml file.