### PR TITLE
Making localhost work with Procfile

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,4 @@
-web:  bundle exec puma -C config/puma.rb
+web:  bundle exec rails server -p 3000 -b localhost
+webpacker: ./bin/webpack-dev-server
+worker: redis-server
 worker: bundle exec sidekiq -q default


### PR DESCRIPTION
I'm not sure why the current Procfile.dev does not work for me in my local machine. Running `foreman start -f Procfile.dev` and then visiting `http://localhost:3000` does not show anything.

Changes done in this PR fixes the issue for me. I'm not sure if this is the right fix.