### PR TITLE
Omit parens for simple arrow functions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
Fixes #440 