### PR TITLE
Rubocop enforce space around operators

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,7 +90,7 @@ Layout/SpaceAroundKeyword:
 #     @current_row_notes          = row["Notes"]
 #     @current_row_hours          = row["Hours"]
 Layout/SpaceAroundOperators:
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceBeforeComma:
   Enabled: true

--- a/package.json
+++ b/package.json
@@ -5,16 +5,13 @@
   "lint-staged": {
     "app/**/*.{html,md,js,jsx,json}": [
       "prettier --write",
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ],
     "{app,test}/**/*.rb": [
-      "bundle exec rubocop -a",
-      "git add"
+      "bundle exec rubocop -a"
     ],
     "Gemfile": [
-      "bundle exec rubocop -a",
-      "git add"
+      "bundle exec rubocop -a"
     ]
   },
   "devDependencies": {

--- a/test/controllers/api/v1/notes_controller_test.rb
+++ b/test/controllers/api/v1/notes_controller_test.rb
@@ -57,7 +57,7 @@ class Api::V1::NotesControllerTest < ActionDispatch::IntegrationTest
     post bulk_delete_api_v1_notes_path, params: { ids: [milk.id] },
         headers: @headers
     assert_response :success
-    assert_equal @admin.notes.size, initial_notes_count-1
+    assert_equal @admin.notes.size, initial_notes_count - 1
   end
 
   def test_delete_multiple_note
@@ -69,7 +69,7 @@ class Api::V1::NotesControllerTest < ActionDispatch::IntegrationTest
     post bulk_delete_api_v1_notes_path, params: { ids: [milk.id, bulbs.id, rent.id] },
         headers: @headers
     assert_response :success
-    assert_equal @admin.notes.size, initial_notes_count-3
+    assert_equal @admin.notes.size, initial_notes_count - 3
   end
 
   def test_delete_invalid_id


### PR DESCRIPTION
1. Rubocop, enforcing space around operators
2. Fixes for the following warning
![image](https://user-images.githubusercontent.com/9862943/126465594-9a00b4ed-e58f-4eb1-97bd-b3aa809a59c6.png)
