### PR TITLE
Added changes to rubocop and eslint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,6 @@ module.exports = {
     "react/prop-types": "off",
     "no-unused-vars": "off",
     "no-undef": "off",
-    "react/no-unescaped-entities": 0
+    "react/no-unescaped-entities": "off"
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     "import/prefer-default-export": "off",
     "react/prop-types": "off",
     "no-unused-vars": "off",
-    "no-undef": "off"
+    "no-undef": "off",
+    "react/no-unescaped-entities": 0
   }
 };

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -195,9 +195,9 @@ Layout/IndentationConsistency:
 #
 #   # do something
 # end
-Layout/MultilineMethodCallIndentation:
-  Enabled: true
-  EnforcedStyle: indented
+# Layout/MultilineMethodCallIndentation:
+#   Enabled: true
+#   EnforcedStyle: indented_relative_to_receiver
 
 # This cop ensures the indentation of the first parameter in a method definition.
 Layout/FirstParameterIndentation:
@@ -389,7 +389,6 @@ Layout/EmptyLineAfterGuardClause:
 # # EOF
 Layout/TrailingEmptyLines:
   Enabled: true
-  EnforcedStyle: final_blank_line
 
 # This cop checks for two or more consecutive blank lines.
 # This rule is not same as TrailingEmptyLines, because:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,10 +47,6 @@ AllCops:
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
 
-Layout/DotPosition:
-  Enabled: true
-  EnforcedStyle: leading
-
 # This cop checks for redundant access modifiers, including those with no code,
 # those which are repeated, and leading `public` modifiers in a class or module body.
 Lint/UselessAccessModifier:
@@ -132,6 +128,12 @@ Layout/EmptyLinesAroundClassBody:
 # ====================================================================================================
 # All Method related rules
 # ====================================================================================================
+# This cop checks the . position in multi-line method calls.
+# The dot should be leading rather than trailing.
+Layout/DotPosition:
+  Enabled: true
+  EnforcedStyle: leading
+
 # No space in method name and the arguments
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,10 @@ AllCops:
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
 
+Layout/DotPosition:
+  Enabled: true
+  EnforcedStyle: leading
+
 # This cop checks for redundant access modifiers, including those with no code,
 # those which are repeated, and leading `public` modifiers in a class or module body.
 Lint/UselessAccessModifier:
@@ -195,9 +199,9 @@ Layout/IndentationConsistency:
 #
 #   # do something
 # end
-# Layout/MultilineMethodCallIndentation:
-#   Enabled: true
-#   EnforcedStyle: indented_relative_to_receiver
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
 
 # This cop ensures the indentation of the first parameter in a method definition.
 Layout/FirstParameterIndentation:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "misogi.ruby-rubocop"
   },
-  "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
   "editor.formatOnSave": true,

--- a/Gemfile
+++ b/Gemfile
@@ -101,4 +101,3 @@ group :test do
   # Minitest reporter plugin for CircleCI.
   gem "minitest-ci"
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,3 @@ require_relative "config/application"
 Rails.application.load_tasks
 
 Knapsack.load_tasks if defined?(Knapsack)
-

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -33,4 +33,3 @@ ActiveAdmin.register_page "Dashboard" do
     # end
   end # content
 end
-

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -12,4 +12,3 @@ ActiveAdmin.register User do
   filter :email
 
 end
-

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -4,4 +4,3 @@ module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end
 end
-

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -4,4 +4,3 @@ module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end
 end
-

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -39,4 +39,3 @@ class Api::V1::BaseController < ApplicationController
       end
     end
 end
-

--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -38,4 +38,3 @@ class Api::V1::NotesController < Api::V1::BaseController
       @note = Note.find(params[:id])
     end
 end
-

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -26,4 +26,3 @@ class Api::V1::SessionsController < Api::V1::BaseController
       user.blank? || !user.valid_password?(params[:user][:password])
     end
 end
-

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -59,4 +59,3 @@ class Api::V1::UsersController < Api::V1::BaseController
       params.require(:user).permit(:email, :first_name, :last_name, :password, :password_confirmation)
     end
 end
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,4 +20,3 @@ class ApplicationController < ActionController::Base
       Honeybadger.context hash
     end
 end
-

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,4 +5,3 @@ class HomeController < ApplicationController
     render
   end
 end
-

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,4 +9,3 @@ class PagesController < ApplicationController
     render
   end
 end
-

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -36,4 +36,3 @@ class RegistrationsController < Devise::RegistrationsController
       self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     end
 end
-

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,4 +5,3 @@ class SessionsController < Devise::SessionsController
     super
   end
 end
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,4 +21,3 @@ module ApplicationHelper
     end
   end
 end
-

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,4 +2,3 @@
 
 class ApplicationJob < ActiveJob::Base
 end
-

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -17,4 +17,3 @@ class Mailer < ActionMailer::Base
     end
   end
 end
-

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,4 +3,3 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end
-

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -5,4 +5,3 @@ class Note < ApplicationRecord
   validates :title, :description, presence: true
   validates :title, uniqueness: true
 end
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,4 +46,3 @@ class User < ApplicationRecord
       end
     end
 end
-

--- a/app/workers/base_worker.rb
+++ b/app/workers/base_worker.rb
@@ -5,4 +5,3 @@ class BaseWorker
     Honeybadger.context(job_name: self.class.name, app_name: Rails.application.engine_name)
   end
 end
-

--- a/app/workers/event_notification_worker.rb
+++ b/app/workers/event_notification_worker.rb
@@ -7,4 +7,3 @@ class EventNotificationWorker < BaseWorker
     # do the business stuff
   end
 end
-

--- a/config.ru
+++ b/config.ru
@@ -6,4 +6,3 @@ require_relative "config/environment"
 
 run Rails.application
 Rails.application.load_server
-

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -6,4 +6,3 @@ Spring.watch(
   "tmp/restart.txt",
   "tmp/caching-dev.txt"
 )
-

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,3 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
-

--- a/test/controllers/active_admin/dashboard_controller_test.rb
+++ b/test/controllers/active_admin/dashboard_controller_test.rb
@@ -16,4 +16,3 @@ class ActiveAdmin::DashboardControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 end
-

--- a/test/controllers/api/v1/notes_controller_test.rb
+++ b/test/controllers/api/v1/notes_controller_test.rb
@@ -83,4 +83,3 @@ class Api::V1::NotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal @admin.notes.size, initial_notes_count
   end
 end
-

--- a/test/controllers/api/v1/sessions_controller_test.rb
+++ b/test/controllers/api/v1/sessions_controller_test.rb
@@ -30,4 +30,3 @@ class Api::V1::SessionsControllerTest < ActionDispatch::IntegrationTest
     assert response.parsed_body["auth_token"]
   end
 end
-

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -160,4 +160,3 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
       create(:user, :admin)
     end
 end
-

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -12,4 +12,3 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 end
-

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -15,4 +15,3 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 end
-

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -76,4 +76,3 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal nancy.first_name, valid_user_data[:first_name]
   end
 end
-

--- a/test/factories/note.rb
+++ b/test/factories/note.rb
@@ -22,4 +22,3 @@ FactoryBot.define do
     end
   end
 end
-

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -19,4 +19,3 @@ FactoryBot.define do
     end
   end
 end
-

--- a/test/integration/api_invalid_json_data_test.rb
+++ b/test/integration/api_invalid_json_data_test.rb
@@ -12,4 +12,3 @@ class ApiInvalidJsonDataTest < ActionDispatch::IntegrationTest
     assert response.body.include?("Something went wrong. Please try again later."), response.body
   end
 end
-

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -32,4 +32,3 @@ class NoteTest < ActiveSupport::TestCase
     assert_includes note.errors.full_messages, "Description can't be blank"
   end
 end
-

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -31,4 +31,3 @@ class UserTest < ActiveSupport::TestCase
     assert_equal expected, @user.as_json
   end
 end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,4 +44,3 @@ def headers(user, options = {})
     "X-Auth-Email" => user.email
   }.merge(options)
 end
-


### PR DESCRIPTION
[Edited by Yedhin] Fixes #566, Fixes #563

@yedhink Please check the updated configurations for rubocop and eslint.

**ESLINT**
`"react/no-unescaped-entities": 0` will not mandate unescaped characters in strings like `", >` etc.

**RUBOCOP**
Added
```
Layout/MultilineMethodCallIndentation:
#   Enabled: true
#   EnforcedStyle: indented_relative_to_receiver
```
Removed
```
Layout/TrailingEmptyLines:
  Enabled: true
  EnforcedStyle: final_blank_line
```
This was creating 2 blank lines at the end. Just having this check enabled will require a single line at the end.


Let me know your opinion.