### PR TITLE
Updated rubocop config to prevent whitespace indentation in ruby files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -432,6 +432,12 @@ Layout/IndentationStyle:
   Enabled: true
   EnforcedStyle: spaces
 
+# Remove extra/unnecessary whitespace which's used for alignment.
+# A developer shouldn't waste time indenting code with whitespaces.
+Layout/ExtraSpacing:
+  Enabled: true
+  AllowForAlignment: false
+
 # Helps in removing unwanted parentheses.
 # # bad
 # x += 1 while (x < 10)

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register_page "Dashboard" do
 
-  menu priority: 1, label:  proc { I18n.t("active_admin.dashboard") }
+  menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 
   content title: proc { I18n.t("active_admin.dashboard") } do
     div class: "blank_slate_container", id: "dashboard_default_message" do

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -10,9 +10,9 @@ class Mailer < ActionMailer::Base
   def contact_email(title, email, body)
     @email = email
     @title = title
-    @body  = body
+    @body = body
     subject = "Contact us message from #{@email}"
-    mail(to: Rails.application.secrets.support_email, from: @email,  subject: subject) do |format|
+    mail(to: Rails.application.secrets.support_email, from: @email, subject: subject) do |format|
       format.html
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,13 +8,13 @@ def enable_test_coverage
   SimpleCov.start do
     add_filter "/test/"
 
-    add_group "Models",       "app/models"
-    add_group "Mailers",      "app/mailers"
-    add_group "Controllers",  "app/controllers"
-    add_group "Uploaders",    "app/uploaders"
-    add_group "Helpers",      "app/helpers"
-    add_group "Workers",      "app/workers"
-    add_group "Services",     "app/services"
+    add_group "Models", "app/models"
+    add_group "Mailers", "app/mailers"
+    add_group "Controllers", "app/controllers"
+    add_group "Uploaders", "app/uploaders"
+    add_group "Helpers", "app/helpers"
+    add_group "Workers", "app/workers"
+    add_group "Services", "app/services"
   end
 end
 


### PR DESCRIPTION
Fixes #557 

- Updated `rubocop.yml`.

@yedhink Please review.