### PR TITLE
Excluded files with .erb extension in rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
     - "app/javascript/**/*"
     - "app/assets/**/*"
     - "app/views/**/*"
+    - "app/views/**/*.erb"
     - "lib/tasks/**/*"
     - ".vscode/**/*"
     - ".husky/**/*"


### PR DESCRIPTION
Fixes #562 