### PR TITLE
Updated Toastr message logic

### DIFF
--- a/app/javascript/src/apis/axios.js
+++ b/app/javascript/src/apis/axios.js
@@ -38,9 +38,9 @@ const handleSuccessResponse = response => {
 const handleErrorResponse = (error, authDispatch) => {
   if (error.response?.status === 401) {
     authDispatch({ type: "LOGOUT" });
-    Toastr.error(error.response?.data?.error);
+    Toastr.error({ error: error.response?.data?.error });
   } else {
-    Toastr.error(error.response?.data?.error || error.message);
+    Toastr.error({ error: error.response?.data?.error || error.message });
   }
   return Promise.reject(error);
 };


### PR DESCRIPTION
Fixes #588 

Screenshot :
<img width="1199" alt="Screenshot 2021-08-24 at 10 23 09 PM" src="https://user-images.githubusercontent.com/17916573/130657776-d5de06fc-db88-4984-b136-83d23f7e7103.png">


Reason for issue:

Logic in neetoui
<img width="1019" alt="Screenshot 2021-08-24 at 10 23 54 PM" src="https://user-images.githubusercontent.com/17916573/130657889-38968069-d183-4063-a352-6ddba9de2963.png">

From the logic, you can see that the `Something went wrong.` is the fallback message.

We are not getting the errorObject as the instance of the `Error`. 
`Promise.reject(error)` code below makes it the instance of Error hence we have wrap inside the json like { error: message}

It is not breaking in other applications since we are showing Toastr in the individual places rather than in the inceptor.

@yedhink _a Please review