### PR TITLE
Added ignored patterns in line-length config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -429,6 +429,14 @@ Layout/CaseIndentation:
 Layout/LineLength:
   Enabled: true
   Max: 120
+  IgnoredPatterns: [
+    '^\s*#', # line that begins with comment
+    '^\s*"', # line that begins with double quote (long string literal)
+    "^\\s*'", # line that begins with single quote (long string literal)
+    '"$', # line that ends with double quote (long string variable assignment)
+    "'$", # line that ends with single quote (long string variable assignment)
+    '\/$', # line that ends with slash (long regex variable assignment)
+  ]
 
 # Indent using two spaces
 Layout/IndentationWidth:

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -100,7 +100,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 10
 
   # Setup a pepper to generate the encrypted password.
-  # config.pepper = 'ad044c347984ac2ec08cb068c17d3e0df8289809a8caa538dc9a565b194d17be203e4421f1c0c9345f97aa112b822d000167ab634e3334385bf4d26674f2310c' # rubocop:disable Layout/LineLength
+  # config.pepper = 'ad044c347984ac2ec08cb068c17d3e0df8289809a8caa538dc9a565b194d17be203e4421f1c0c9345f97aa112b822d000167ab634e3334385bf4d26674f2310c'
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without


### PR DESCRIPTION
This avoids flagging false positives (long strings, long regexes, and long comments) as offenses.
Fixes #605 