### PR TITLE
Fixes an issue occurred on heroku for redis6

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,7 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= Rails.application.secrets.redis_url %>
   channel_prefix: wheel_production
+  ssl_params:
+    verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -14,7 +14,14 @@ end
 Sidekiq::Extensions.enable_delay!
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: Rails.application.secrets.redis_url, size: 9 }
+  config.redis = {
+    url: Rails.application.secrets.redis_url,
+    size: 9,
+    ssl_params: {
+      verify_mode: OpenSSL::SSL::VERIFY_NONE
+    }
+  }
+
   schedule_file = Rails.root.join("config/schedule.yml")
 
   if File.exists?(schedule_file)
@@ -23,5 +30,11 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: Rails.application.secrets.redis_url, size: 1 }
+  config.redis = {
+    url: Rails.application.secrets.redis_url,
+    size: 1,
+    ssl_params: {
+      verify_mode: OpenSSL::SSL::VERIFY_NONE
+    }
+  }
 end


### PR DESCRIPTION
Fixes the following issue:

> OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain)

Reference: https://github.com/bigbinary/neeto-desk-web/issues/11340