### PR TITLE
Allowing sanitised html for dangerouslySetInnerHTML

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,12 +72,7 @@ module.exports = {
     "jam3/no-sanitizer-with-danger": [
       2,
       {
-        wrapperName: [
-          "dompurify",
-          "sanitizer",
-          "sanitize",
-          "dompurify.sanitize"
-        ]
+        wrapperName: ["dompurify", "sanitizer", "sanitize"]
       }
     ],
     // not-auto-fixable: Report when a DOM element is using both children and dangerouslySetInnerHTML.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
     sourceType: "module"
   },
   parser: "babel-eslint",
-  plugins: ["react", "prettier", "import", "react-hooks", "promise"],
+  plugins: ["react", "prettier", "import", "react-hooks", "promise", "jam3"],
   rules: {
     // auto-fixable: Respect all Prettier rules and apply it.
     "prettier/prettier": "error",
@@ -68,8 +68,18 @@ module.exports = {
     "react/display-name": "error",
     // not-auto-fixable: Reports when this.state is accessed within setState.
     "react/no-access-state-in-setstate": "error",
-    // not-auto-fixable: Prevent usage of dangerous JSX props.
-    "react/no-danger": "error",
+    // not-auto-fixable: Prevent un-sanitized dangerouslySetInnerHTML.
+    "jam3/no-sanitizer-with-danger": [
+      2,
+      {
+        wrapperName: [
+          "dompurify",
+          "sanitizer",
+          "sanitize",
+          "dompurify.sanitize"
+        ]
+      }
+    ],
     // not-auto-fixable: Report when a DOM element is using both children and dangerouslySetInnerHTML.
     "react/no-danger-with-children": "error",
     // not-auto-fixable: Prevent definitions of unused prop types.

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 if [ -z "$husky_skip_init" ]; then
   debug () {
-    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+    if [ "$HUSKY_DEBUG" = "1" ]; then
+      echo "husky (debug) - $1"
+    fi
   }
 
   readonly hook_name="$(basename "$0")"
@@ -23,8 +25,7 @@ if [ -z "$husky_skip_init" ]; then
 
   if [ $exitCode != 0 ]; then
     echo "husky - $hook_name hook exited with code $exitCode (error)"
-    exit $exitCode
   fi
 
-  exit 0
+  exit $exitCode
 fi

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-preset-react": "^6.24.1",
     "classnames": "^2.2.6",
     "core-js": "3.7.0",
+    "eslint-plugin-jam3": "^0.2.3",
     "formik": "^2.2.5",
     "js-logger": "^1.6.1",
     "moment": "^2.29.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3526,6 +3526,15 @@ eslint-plugin-import@^2.24.2:
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
 
+eslint-plugin-jam3@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jam3/-/eslint-plugin-jam3-0.2.3.tgz#49a0ac99e4f442c10c0b2dfd4537afc59b16ee4e"
+  integrity sha512-aW1L8C96fsRji0c8ZAgqtJVIu5p2IaNbeT2kuHNS6p5tontAVK1yP1W4ECjq3BHOv/GgAWvBVIx7kQI0kG2Rew==
+  dependencies:
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    requireindex "~1.1.0"
+
 eslint-plugin-json@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz#251108ba1681c332e0a442ef9513bd293619de67"
@@ -7735,6 +7744,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is required as we mostly use ActionText and we render the content using `dangerouslySetInnerHTML`. 
With the current eslint restrictions, those instances are not valid anymore. 

This PR allows sanitised content under `dangerouslySetInnerHTML`.

### Example:

**Bad:**
```jsx
<div dangerouslySetInnerHTML={{ __html: content }} />
```

**Good:**
```jsx
const sanitizer = dompurify.sanitize;
<div dangerouslySetInnerHTML={{ __html: sanitizer(content) }} />
```



@unnitallman _a please review.