### PR TITLE
Added eslint job into semaphore config

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -43,6 +43,14 @@ blocks:
           commands:
             - bundle exec rubocop
 
+        - name: Eslint
+          commands:
+            - checkout
+            - git fetch --unshallow
+            - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+            - git fetch origin master
+            - git diff-tree -r --no-commit-id --name-only HEAD remotes/origin/master | grep --color=none -i -e "\.js$" -e "\.jsx$" | xargs npx eslint
+
   - name: Tests
     task:
       jobs:


### PR DESCRIPTION
Fixes #621 

This PR can be merged safely in wheel given that neetoCompliance doesn't enforce `semaphore.yml` config to be aligned with wheel yet.