### PR TITLE
Filter out deleted files in semaphore eslint

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,7 +49,7 @@ blocks:
             - git fetch --unshallow
             - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
             - git fetch origin master
-            - git diff-tree -r --no-commit-id --name-only HEAD remotes/origin/master | grep --color=none -i -e "\.js$" -e "\.jsx$" | xargs npx eslint
+            - git diff-tree --diff-filter=a -r --no-commit-id --name-only HEAD remotes/origin/master | grep --color=none -i -e "\.js$" -e "\.jsx$" | xargs npx eslint
 
   - name: Tests
     task:


### PR DESCRIPTION
Fixes #637 

When diffing between branches, inversion happens with files. Thus filter should be `a` and not `d`.