### PR TITLE
Removed VSCode rubocop extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
     "kaiwood.endwise",
     "rebornix.ruby",
     "redhat.vscode-yaml",
-    "editorconfig.editorconfig",
-    "misogi.ruby-rubocop"
+    "editorconfig.editorconfig"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,11 +2,20 @@
   "[ruby]": {
     "editor.autoClosingBrackets": "beforeWhitespace",
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "misogi.ruby-rubocop"
+    "editor.defaultFormatter": "rebornix.ruby"
   },
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
   "editor.formatOnSave": true,
   "yaml.format.enable": true,
-  "ruby.rubocop.useBundler": true
+  "ruby.useBundler": true, //run non-lint commands with bundle exec
+  "ruby.useLanguageServer": true, // use the internal language server (see below)
+  "ruby.lint": {
+    "rubocop": {
+      "useBundler": true,
+      "lint": true, // enable lint cops
+      "rails": true // requires rubocop-rails gem for RuboCop >= 0.72.0
+    }
+  },
+  "ruby.format": "rubocop",
 }


### PR DESCRIPTION
Fixes #703 

Changes 
* Removed the `misogi.ruby-rubocop` extension from the list of recommended extensions for VSCode.
* Addede custom configs in `.vscode/settings.json` file to format ruby files on save using the rubocop gem installed in the project.

Please review the changes, thank you.

@yedhink _a