### PR TITLE
Upgrade gcc version for semaphoreCI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,6 +11,7 @@ global_job_config:
       - checkout
       - sem-version ruby 3.0.2
       - sem-version node 16.5
+      - sem-version c 8
       - sem-service start postgres 12.4
       - cache restore
       - bundle config set --local path 'vendor/bundle'


### PR DESCRIPTION
By default, gcc v4 caused random failures for `bundle install` step.
Upgrading gcc to v8 fixes the issue.