### PR TITLE
Disable logger in production env

### DIFF
--- a/app/javascript/src/common/logger.js
+++ b/app/javascript/src/common/logger.js
@@ -2,7 +2,7 @@ export const initializeLogger = () => {
   /* eslint react-hooks/rules-of-hooks: "off" */
   const Logger = require("js-logger");
   Logger.useDefaults();
-  if (process.env.NODE_ENV === "production") {
+  if (process.env.RAILS_ENV === "production") {
     Logger.setLevel(Logger.OFF);
   }
 };

--- a/app/javascript/src/common/logger.js
+++ b/app/javascript/src/common/logger.js
@@ -1,4 +1,8 @@
 export const initializeLogger = () => {
-  /* eslint no-undef: "off"*/
-  require("js-logger").useDefaults();
+  /* eslint react-hooks/rules-of-hooks: "off" */
+  const Logger = require("js-logger");
+  Logger.useDefaults();
+  if (process.env.NODE_ENV === "production") {
+    Logger.setLevel(Logger.OFF);
+  }
 };


### PR DESCRIPTION
@chiraggshah _a

Questions:
- Should we use `RAILS_ENV` over `NODE_ENV` to check for current environment given that there are envs like `heroku`, `staging` etc?
- Should we disable this logger in any other environment, other than just `production`?

Please review and verify.

