### PR TITLE
Fixed browser force quit and session clearing issues

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: "_wheel_session"
+Rails.application.config.session_store :cookie_store, key: "_wheel_session", expire_after: 7.days


### PR DESCRIPTION
Fixes #774 

So the best way to deal with this issue is to set an expiry for the session. This way, even after browser force quit session remains persisted until its expiry.

PS: Don't browser force quit, session getting destroyed is the intended behaviour.

cc: @Amaljith-K 