### PR TITLE
Sync bin folder to neeto

### DIFF
--- a/.scripts/sync_with_wheel.sh
+++ b/.scripts/sync_with_wheel.sh
@@ -42,6 +42,15 @@ declare -a configs=(
   ".nvmrc"
   ".ruby-version"
   ".erb-lint.yml"
+  "bin/bundle"
+  "bin/rails"
+  "bin/rake"
+  "bin/setup"
+  "bin/spring"
+  "bin/update"
+  "bin/webpack"
+  "bin/webpack-dev-server"
+  "bin/yarn"
 )
 
 for config in "${configs[@]}"; do


### PR DESCRIPTION
Fixes #791 

@unnitallman _a Can you please review and merge this?

This PR ensures that if we upgrade the Rails version in wheel and if any specific changes occurs to the files in `./bin` folder at the root of wheel, then it gets synced to all neeto repos.

In Rails 7 etc, `spring` gem gets removed and thus most of the files under this folder needs to be changed across neeto. 

This PR would automate that part.