### PR TITLE
Made nested ternary a warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,8 +97,8 @@ module.exports = {
     "no-unsafe-optional-chaining": "error",
     // auto-fixable: Remove all unused imports.
     "unused-imports/no-unused-imports": "error",
-    // auto-fixable-1-level-deep: Using nested ternary operators make the code unreadable. Use if/else or switch with if/else. If it's JSX then move it out into a function or a variable.
-    "no-nested-ternary": "error",
+    // auto-fixable-1-level-deep: Using nested ternary operators make the code unreadable. Use if/else or switch with if/else. If it's JSX then move it out into a function or a variable. It's fine to use nestedTernary in JSX when it makes code more readable.
+    "no-nested-ternary": "warn",
     // auto-fixable: Enforces no braces where they can be omitted.
     "arrow-body-style": ["error", "as-needed"],
     // auto-fixable: Suggests using template literals instead of string concatenation.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,15 +193,11 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
     minitest (5.15.0)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     msgpack (1.5.1)
     nio4r (2.5.8)
-    nokogiri (1.13.4)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -271,13 +267,13 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
-    rubocop (1.27.0)
+    rubocop (1.28.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.16.0, < 2.0)
+      rubocop-ast (>= 1.17.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.17.0)
@@ -301,7 +297,7 @@ GEM
       sprockets-rails
       tilt
     semantic_range (3.0.0)
-    sidekiq (6.4.1)
+    sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -349,8 +345,6 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
-  ruby
-  x86_64-darwin-20
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2021_05_19_154812) do
     t.string "resource_id", null: false
     t.string "resource_type", null: false
     t.string "author_type"
-    t.bigint "author_id"
+    t.integer "author_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"


### PR DESCRIPTION
Fixes #826 

It's safe to keep it's as a warning for the time being. It's non-blocking in nature but yet conveys the message that nesting should always be looked into as part of code standards.