### PR TITLE
Fix Husky pre-commit Error

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -20,7 +20,7 @@ if [ -z "$husky_skip_init" ]; then
   fi
 
   export readonly husky_skip_init=1
-  bash -e "$0" "$@"
+  sh -e "$0" "$@"
   exitCode="$?"
 
   if [ $exitCode != 0 ]; then

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -20,7 +20,7 @@ if [ -z "$husky_skip_init" ]; then
   fi
 
   export readonly husky_skip_init=1
-  sh -e "$0" "$@"
+  bash -e "$0" "$@"
   exitCode="$?"
 
   if [ $exitCode != 0 ]; then

--- a/.husky/helpers/prevent_conflict_markers.sh
+++ b/.husky/helpers/prevent_conflict_markers.sh
@@ -4,7 +4,7 @@ repeat() {
   char="$1"
   times="$2"
   text=""
-  i="0"
+  i=0
 
   while [ $i -lt $times ]
   do

--- a/.husky/helpers/prevent_conflict_markers.sh
+++ b/.husky/helpers/prevent_conflict_markers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 repeat() {
   char="$1"

--- a/.husky/helpers/prevent_conflict_markers.sh
+++ b/.husky/helpers/prevent_conflict_markers.sh
@@ -4,9 +4,12 @@ repeat() {
   char="$1"
   times="$2"
   text=""
-  for (( i = 0; i < "$times"; ++i ))
+  i="0"
+
+  while [ $i -lt $times ]
   do
     text="${text}${char}"
+    i=$((i+1))
   done
   echo "$text"
 }


### PR DESCRIPTION
Fixes #853

## What
Modified for loop with while loop, which is actively being supported by `sh` shell.

## Why
Looping constructs (i.e. _for_ loop) being called in `.husky/helpers/prevent_conflict_markers.sh:7` is not supported by _sh_ shell as is feature part of _bash_ shell, as mentioned [here](https://www.gnu.org/software/bash/manual/bash.html#Looping-Constructs).