### PR TITLE
Fix column types for active storage related tables

### DIFF
--- a/db/migrate/20210519154811_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210519154811_create_active_storage_tables.active_storage.rb
@@ -18,7 +18,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
     create_table :active_storage_attachments do |t|
       t.string :name, null: false
-      t.references :record, null: false, polymorphic: true, index: false
+      t.references :record, null: false, polymorphic: true, index: false, type: :uuid
       t.references :blob, null: false
 
       t.datetime :created_at, null: false
@@ -28,7 +28,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
-    create_table :active_storage_variant_records do |t|
+    create_table :active_storage_variant_records, id: :uuid do |t|
       t.belongs_to :blob, null: false, index: false
       t.string :variation_digest, null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,7 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_29_042750) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
+    t.uuid "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_29_042750) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade do |t|
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true


### PR DESCRIPTION
Faced this issue while cloning a new app with wheel.
All our models have primary key as uuid, but active record attachment was using bigint to store the record id.

Similarly changed it for variants table as well.

Ref: https://edgeguides.rubyonrails.org/active_storage_overview.html#setup

> If you are using UUIDs instead of integers as the primary key on your models you will need to change the column type of active_storage_attachments.record_id and active_storage_variant_records.id in the generated migration accordingly.