### PR TITLE
Fix import resolvers in eslint

### DIFF
--- a/.eslint-rules/imports/enforced.js
+++ b/.eslint-rules/imports/enforced.js
@@ -22,7 +22,7 @@ module.exports = {
       "never",
       {
         ignorePackages: true,
-        pattern: { json: "always", mp3: "always" }
+        pattern: { json: "always", mp3: "always" },
       },
     ],
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,12 @@ module.exports = {
     react: {
       version: "detect",
     },
+    // We need this for the import/extensions rule to work: https://github.com/import-js/eslint-plugin-import#importextensions
+    "import/resolver": {
+      node: {
+        extensions: [".js", ".jsx", ".ts", ".tsx", ".svg", ".json", ".mp3"],
+      },
+    },
   },
   parserOptions: {
     ecmaFeatures: {

--- a/app/javascript/src/components/Dashboard/Settings/constants.js
+++ b/app/javascript/src/components/Dashboard/Settings/constants.js
@@ -1,33 +1,5 @@
 import * as yup from "yup";
 
-import Email from "./Email";
-import Password from "./Password";
-import Profile from "./Profile";
-
-export const SETTINGS_NAVLINKS = [
-  {
-    key: "profile",
-    label: "Profile",
-    description: "Manage user",
-    path: "/settings?tab=profile",
-    component: Profile,
-  },
-  {
-    key: "email",
-    label: "Email",
-    description: "Manage email",
-    path: "/settings?tab=email",
-    component: Email,
-  },
-  {
-    key: "password",
-    label: "Password",
-    description: "Manage password",
-    path: "/settings?tab=password",
-    component: Password,
-  },
-];
-
 export const PROFILE_FORM_VALIDATION_SCHEMA = yup.object().shape({
   firstName: yup.string().required("Required"),
   lastName: yup.string().required("Required"),

--- a/app/javascript/src/components/Dashboard/Settings/index.jsx
+++ b/app/javascript/src/components/Dashboard/Settings/index.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from "react";
 import { MenuBar } from "neetoui/layouts";
 import queryString from "query-string";
 
-import { SETTINGS_NAVLINKS } from "./constants";
+import { SETTINGS_NAVLINKS } from "./navLinks";
 import { getActiveNavLink } from "./utils";
 
 const Settings = ({ history, location }) => {

--- a/app/javascript/src/components/Dashboard/Settings/navLinks.js
+++ b/app/javascript/src/components/Dashboard/Settings/navLinks.js
@@ -1,0 +1,28 @@
+import Email from "./Email";
+import Password from "./Password";
+import Profile from "./Profile";
+
+// Note: This is not kept in constants.js to avoid dependency cycle
+export const SETTINGS_NAVLINKS = [
+  {
+    key: "profile",
+    label: "Profile",
+    description: "Manage user",
+    path: "/settings?tab=profile",
+    component: Profile,
+  },
+  {
+    key: "email",
+    label: "Email",
+    description: "Manage email",
+    path: "/settings?tab=email",
+    component: Email,
+  },
+  {
+    key: "password",
+    label: "Password",
+    description: "Manage password",
+    path: "/settings?tab=password",
+    component: Password,
+  },
+];

--- a/app/javascript/src/components/Dashboard/Settings/utils.js
+++ b/app/javascript/src/components/Dashboard/Settings/utils.js
@@ -1,4 +1,4 @@
-import { SETTINGS_NAVLINKS } from "./constants";
+import { SETTINGS_NAVLINKS } from "./navLinks";
 
 export const getActiveNavLink = key =>
   SETTINGS_NAVLINKS.find(navlink => key === navlink.key);

--- a/app/javascript/src/jsconfig.json
+++ b/app/javascript/src/jsconfig.json
@@ -8,7 +8,8 @@
     "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
-      "neetoui": ["@bigbinary/neetoui"]
+      "neetoui/*": ["../../../node_modules/@bigbinary/neetoui/*"],
+      "neetoui": ["../../../node_modules/@bigbinary/neetoui"]
     },
     "pretty": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
@josephmathew900 _a Please verify the Eslint config changes from this PR. The other changes are side effects of applying the eslint configs.

With https://github.com/bigbinary/wheel/pull/903 I was able to import relative paths with extension.

Example:
- If we add a `.jsx` extension for `Main` in [this import](https://github.com/bigbinary/wheel/blob/master/app/javascript/src/App.jsx#L6), then the eslint rule would NOT complain.

Our expectation is that it will complain like so, which I have resolved in this PR:
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/31244999/191525692-92d98a38-d135-4de0-b039-0a311ddb4d44.png">


Can you please check out how this config is playing in few of the neeto apps and if everything looks good, merge this PR? If there are any issues then lemme know.