### PR TITLE
Fix rubocop class structure rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,9 @@ Layout/ClassStructure:
       - include
       - prepend
       - extend
+    third_party:
+      - neeto_sso_track_widget_tokens
+      - devise
     scopes:
       - default_scope
       - scope
@@ -120,8 +123,6 @@ Layout/ClassStructure:
       - has_many
       - has_and_belongs_to_many
     other_macros:
-      - neeto_sso_track_widget_tokens
-      - devise
       - delegate
       - accepts_nested_attributes_for
     validations:
@@ -157,6 +158,7 @@ Layout/ClassStructure:
       - after_create_commit
   ExpectedOrder:
       - module_inclusions
+      - third_party
       - scopes
       - constants
       - attributes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+    :recoverable, :trackable, :validatable, :rememberable
   has_many :notes, dependent: :delete_all
 
   validates :email, uniqueness: true
@@ -8,11 +12,6 @@ class User < ApplicationRecord
   validates :first_name, :last_name, :email, presence: true
 
   before_save :ensure_authentication_token_is_present
-
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-    :recoverable, :trackable, :validatable, :rememberable
 
   def name
     [first_name, last_name].join(" ").strip


### PR DESCRIPTION
Part of #947 

Was an interesting issue. So `devise` adds a `validatable` module which itself adds validations for password and password_confirmation. If we move this macro below our custom password_confirmation validation, then the error message generated will be different, in the sense the order of error messages will be different.

<img width="617" alt="image" src="https://user-images.githubusercontent.com/31244999/213153617-b2b72225-c312-4a7b-a852-f2cedb211bf6.png">


Thus it's best to keep the 3rd party macros towards the very top.