### PR TITLE
Added script to run Rubocop and Erblint on modified files

### DIFF
--- a/.scripts/run_rubocop_and_erblint_on_modified_files.sh
+++ b/.scripts/run_rubocop_and_erblint_on_modified_files.sh
@@ -1,0 +1,7 @@
+git fetch --unshallow 2> /dev/null
+git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+git fetch origin main
+new_files=$(git diff-tree --diff-filter=a -r --no-commit-id --name-only HEAD remotes/origin/main)
+echo "$new_files" | xargs bundle exec rubocop --force-exclusion
+echo "$new_files" | xargs bundle exec erblint --lint-all --format compact
+


### PR DESCRIPTION
Fixes #1045

- The Rubocop and Erblint currently run on every file. This is counterproductive while writing custom cops in rubocop-neeto. We might introduce several new cops. This will introduce unnecessary noise to existing PRs.
- Similar to how we handle ESlint, we should execute the Rubocop and Erblint changes on changed files. This PR adds a script to perform this operation.
- This script will be used within the NeetoCI and Audit commands.
