### PR TITLE
Do not execute RuboCop if there are no file changes

### DIFF
--- a/.scripts/run_rubocop_and_erblint_on_modified_files.sh
+++ b/.scripts/run_rubocop_and_erblint_on_modified_files.sh
@@ -1,5 +1,12 @@
 git fetch --unshallow 2> /dev/null
 git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 git fetch origin main
-git diff-tree --diff-filter=a -r --no-commit-id --name-only HEAD remotes/origin/main | xargs bundle exec rubocop --force-exclusion
+
+CHANGED_FILES=$(git diff-tree --diff-filter=a -r --no-commit-id --name-only HEAD remotes/origin/main)
+
+if [ -n "$CHANGED_FILES" ]; then
+  echo "$CHANGED_FILES" | xargs bundle exec rubocop --force-exclusion
+else
+  echo "No file changes detected. Skipping RuboCop."
+fi
 


### PR DESCRIPTION
Fixes #1047 

- Do not execute RuboCop if there are no file changes.