### PR TITLE
replacing CraigMaslowski.erb extension for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint",
     "streetsidesoftware.code-spell-checker",
-    "CraigMaslowski.erb",
+    "bung87.rails",
     "eamodio.gitlens"
   ]
 }


### PR DESCRIPTION
changes  CraigMaslowski.erb extension to the official rails extension as erb is no longer maintained and the maintainer recommends to use the official rails extension.