### PR TITLE
# Replace sass-rails with dartsass-rails and migrate SCSS imports to @use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "rails", "~> 7.1.3.4"
 gem "sprockets"
 
 # friends of Rails
-gem "sass-rails", ">= 6"
+gem "dartsass-rails"
 gem "sprockets-rails"
 gem "uglifier", ">= 2.7.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,9 @@ GEM
     connection_pool (2.5.0)
     crass (1.0.6)
     csv (3.3.2)
+    dartsass-rails (0.5.1)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     date (3.4.1)
     devise (4.9.4)
       bcrypt (~> 3.0)
@@ -172,6 +175,27 @@ GEM
     formtastic_i18n (0.7.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.33.0)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
     has_scope (0.8.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -368,16 +392,22 @@ GEM
     ruby2_keywords (0.0.5)
     ruby_audit (3.0.0)
       bundler-audit (~> 0.9.0)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.94.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     sidekiq (7.3.9)
       base64
       connection_pool (>= 2.3.0)
@@ -440,6 +470,7 @@ DEPENDENCIES
   bootsnap (>= 1.9.4)
   bullet
   bundler-audit
+  dartsass-rails
   devise (~> 4.7)
   email_prefixer
   email_validator
@@ -461,7 +492,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   ruby_audit
-  sass-rails (>= 6)
   sidekiq (< 8)
   simplecov
   sprockets

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,13 +1,8 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@use "tailwindcss/base" as *;
+@use "tailwindcss/components" as *;
+@use "tailwindcss/utilities" as *;
+@use "@bigbinary/neetoui" as *;
+@use "layouts/sidebar" as *;
+@use "components/notes" as *;
 
 @import "react-toastify/dist/ReactToastify.min.css";
-
-@import "@bigbinary/neetoui";
-
-//Sidebar
-@import "layouts/sidebar";
-
-//Components
-@import "components/notes";

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,20 @@
+const replaceColorAdjust = () => {
+  return {
+    postcssPlugin: "postcss-replace-color-adjust",
+    Declaration(decl) {
+      if (decl.prop === "color-adjust") {
+        decl.prop = "print-color-adjust";
+      }
+    },
+  };
+};
+replaceColorAdjust.postcss = true;
+
 module.exports = {
   plugins: [
     require("postcss-import"),
     require("tailwindcss")("./tailwind.config.js"),
+    replaceColorAdjust,
     require("postcss-flexbugs-fixes"),
     require("postcss-preset-env")({
       autoprefixer: {


### PR DESCRIPTION
## Overview
This PR replaces the `sass-rails` gem with `dartsass-rails` to resolve compatibility issues with the current Rails setup, updates the main SCSS entry to address Dart Sass deprecation / ordering warnings, and adds a PostCSS plugin to handle CSS property deprecations.

## Changes
- Replaced `gem "sass-rails", ">= 6"` with `gem "dartsass-rails"` in `Gemfile`
- Updated `Gemfile.lock` with the new dependency
- Updated `app/javascript/stylesheets/application.scss`:
  - Replaced project `@import` usages with `@use "<path>" as *;` (minimal, non-breaking)
  - Reordered imports so all `@use` rules are at the top (required by Dart Sass)
  - Left the third-party CSS import (`react-toastify/dist/ReactToastify.min.css`) after the `@use` block
- Updated `postcss.config.js`:
  - Added custom PostCSS plugin to replace deprecated `color-adjust` property with `print-color-adjust`
  - Silences PostCSS deprecation warnings during Vite builds

## Why
- `sass-rails` produced build errors with the current Ruby / Rails environment.
- `dartsass-rails` uses Dart Sass and resolves the initial compatibility failures.
- Dart Sass deprecates `@import`; migrating to `@use` removes deprecation warnings and prevents future breakage.
- PostCSS deprecation warnings about `color-adjust` are addressed with automatic property replacement.

## What I verified
- The gem and lockfile are updated in this branch.
- The main SCSS entry compiles with Dart Sass when `node_modules` is in the load path.
- Dev stack starts without the previous `@use` ordering error. The PostCSS plugin silences `color-adjust` warnings.
- Note: a full `npx vite build` failed due to a missing entry unrelated to these changes; SCSS-related errors no longer occur.

<img width="585" height="179" alt="image" src="https://github.com/user-attachments/assets/79e1ed1c-aadd-42ad-9e75-9b1b8ad2f332" />`